### PR TITLE
Reaper tabs in ReaSyntax.sublime-settings

### DIFF
--- a/ReaSyntax.sublime-settings
+++ b/ReaSyntax.sublime-settings
@@ -1,7 +1,11 @@
 // Never edit this file (it will get overwritten on update) - use for reference only.
 // To edit settings add stuff to "User/ReaSyntax.sublime-settings"
 // For easy access to the file go to Preferences->Package Settings->ReaSyntax->Settings - User
-{
+{	
+	//Set the tab size to 2 and use spaces as inside the Reaper's editor.
+	"tab_size": 2,
+	"translate_tabs_to_spaces": true,
+	
 	// Set colors to use with JS syntax. To disable and use global colors do "color_scheme_js": null
 	"color_scheme_js": "Packages/ReaSyntax/Default.tmTheme",
 


### PR DESCRIPTION
Set the tabs like the js and reascript IDEs inside Reaper